### PR TITLE
Remove `decode` mentions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ easy to read and easy to modify.
 Here is a decoder built with this library.
 
 ```elm
-import Json.Decode exposing (int, string, float, Decoder)
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode as Decode exposing (Decoder, int, string, float)
+import Json.Decode.Pipeline exposing (required, optional, hardcoded)
 
 
 type alias User =
@@ -49,7 +49,7 @@ type alias User =
 
 userDecoder : Decoder User
 userDecoder =
-  decode User
+  Decode.succeed User
     |> required "id" int
     |> required "email" (nullable string) -- `null` decodes to `Nothing`
     |> optional "name" string "(fallback if name is `null` or not present)"
@@ -58,7 +58,6 @@ userDecoder =
 
 In this example:
 
-* `decode` is a synonym for [`succeed`](http://package.elm-lang.org/packages/elm-lang/core/3.0.0/Json-Decode#succeed) (it just reads better here)
 * `required "id" int` is similar to `(field "id" int)`
 * `optional` is like `required`, but if the field is either `null` or not present, decoding does not fail; instead it succeeds with the provided fallback value.
 * `hardcoded` does not look at the provided JSON, and instead always decodes to the same value.


### PR DESCRIPTION
`Decode.succeed` should be used instead