### PR TITLE
Update README.md, exposing nullable in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ easy to read and easy to modify.
 Here is a decoder built with this library.
 
 ```elm
-import Json.Decode as Decode exposing (Decoder, int, string, float)
+import Json.Decode as Decode exposing (Decoder, int, string, float, nullable)
 import Json.Decode.Pipeline exposing (required, optional, hardcoded)
 
 


### PR DESCRIPTION
The example uses `nullable` from `Json.Decode` but the impot doesn't expose it.