### PR TITLE
correct spelling, update link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # json-decode-pipeline
 
-Build JSON decoders using the pipeline [`(|>)`](http://package.elm-lang.org/packages/elm-lang/core/3.0.0/Basics#|>)
+Build JSON decoders using the pipeline [`(|>)`](https://package.elm-lang.org/packages/elm/core/1.0.5/Basics#|>)
 operator.
 
 ## Motivation

--- a/src/Json/Decode/Pipeline.elm
+++ b/src/Json/Decode/Pipeline.elm
@@ -149,7 +149,7 @@ optionalDecoder pathDecoder valDecoder fallback =
 
 
 {-| Rather than decoding anything, use a fixed value for the next step in the
-pipeline. `harcoded` does not look at the JSON at all.
+pipeline. `hardcoded` does not look at the JSON at all.
 
     import Json.Decode as Decode exposing (Decoder, int, string)
     import Json.Decode.Pipeline exposing (required)


### PR DESCRIPTION
- updated `(|>)` link
- corrected `harcoded` spelling in the doc to `hardcoded`
